### PR TITLE
Setup jobrunr cron service with r2dbc and jdbc isolation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 # =============================================================================
 spring-boot = "3.5.4"
 spring-dependency-management = "1.1.6"
+jobrunr = "6.3.3"
 
 # =============================================================================
 # DATABASE VERSIONS
@@ -59,6 +60,7 @@ auth0-java-jwt = { group = "com.auth0", name = "java-jwt", version.ref = "auth0-
 # =============================================================================
 postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql" }
 r2dbc-postgresql = { group = "org.postgresql", name = "r2dbc-postgresql", version.ref = "r2dbc-postgresql" }
+jobrunr-starter = { group = "org.jobrunr", name = "jobrunr-spring-boot-3-starter", version.ref = "jobrunr" }
 
 # =============================================================================
 # DATABASE MIGRATION (Versions managed by version.ref)

--- a/libs/integration/cron/build.gradle.kts
+++ b/libs/integration/cron/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("build.library")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    api(libs.jobrunr.starter)
+    implementation(platform(libs.spring.boot.bom))
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    testImplementation(platform(libs.spring.boot.bom))
+}
+

--- a/libs/integration/cron/src/main/java/com/exxus/integration/cron/config/JobRunrConfig.java
+++ b/libs/integration/cron/src/main/java/com/exxus/integration/cron/config/JobRunrConfig.java
@@ -1,0 +1,21 @@
+package com.exxus.integration.cron.config;
+
+import javax.sql.DataSource;
+
+import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.sql.postgres.PostgresStorageProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JobRunrConfig {
+
+  @Bean
+  @ConditionalOnBean(DataSource.class)
+  @ConditionalOnMissingBean(StorageProvider.class)
+  public StorageProvider storageProvider(DataSource dataSource) {
+    return new PostgresStorageProvider(dataSource);
+  }
+}

--- a/libs/integration/cron/src/main/java/com/exxus/integration/cron/jobs/SampleJob.java
+++ b/libs/integration/cron/src/main/java/com/exxus/integration/cron/jobs/SampleJob.java
@@ -1,0 +1,17 @@
+package com.exxus.integration.cron.jobs;
+
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SampleJob {
+
+  private static final Logger log = LoggerFactory.getLogger(SampleJob.class);
+
+  public void process() {
+    log.info("SampleJob.process executed at {}", Instant.now());
+  }
+}

--- a/services/core/build.gradle.kts
+++ b/services/core/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     
     // Project modules
     implementation(project(":libs:shared"))
+    implementation(project(":libs:integration:cron"))
 }

--- a/services/core/src/main/java/nexxus/core/controller/TriggerJobController.java
+++ b/services/core/src/main/java/nexxus/core/controller/TriggerJobController.java
@@ -1,0 +1,36 @@
+package nexxus.core.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/jobs")
+public class TriggerJobController {
+
+  private final WebClient webClient;
+  private final String schedulerBaseUrl;
+
+  public TriggerJobController(
+      WebClient.Builder webClientBuilder,
+      @Value("${exxus.scheduler.base-url}") String schedulerBaseUrl) {
+    this.webClient = webClientBuilder.build();
+    this.schedulerBaseUrl = schedulerBaseUrl;
+  }
+
+  @PostMapping("/trigger")
+  public Mono<ResponseEntity<Void>> triggerSampleJob() {
+    return webClient
+        .post()
+        .uri(schedulerBaseUrl + "/internal/jobs/sample/trigger")
+        .retrieve()
+        .toBodilessEntity()
+        .map(response -> new ResponseEntity<Void>(HttpStatus.ACCEPTED));
+  }
+}

--- a/services/core/src/main/resources/application.yml
+++ b/services/core/src/main/resources/application.yml
@@ -10,6 +10,10 @@ spring:
   config:
     import:
       - optional:classpath:/application-common.yml
+  r2dbc:
+    url: ${SPRING_R2DBC_URL:r2dbc:postgresql://localhost:5432/exxus_core}
+    username: ${SPRING_R2DBC_USERNAME:exxus}
+    password: ${SPRING_R2DBC_PASSWORD:secret}
 
 # Management Configuration (Core service specific)
 management:
@@ -20,3 +24,14 @@ management:
   endpoint:
     health:
       show-details: ${MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS}
+
+org:
+  jobrunr:
+    background-job-server:
+      enabled: false
+    dashboard:
+      enabled: false
+
+exxus:
+  scheduler:
+    base-url: ${EXXUS_SCHEDULER_BASE_URL:http://localhost:8081}

--- a/services/scheduler/build.gradle.kts
+++ b/services/scheduler/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("build.service")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation(platform(libs.spring.boot.bom))
+
+    implementation(project(":libs:integration:cron"))
+    implementation(libs.jobrunr.starter)
+
+    implementation(libs.spring.boot.starter.webflux)
+    // JDBC strictly for scheduler service for JobRunr storage provider
+    implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
+    runtimeOnly(libs.postgresql)
+}
+

--- a/services/scheduler/src/main/java/com/exxus/scheduler/SchedulerApplication.java
+++ b/services/scheduler/src/main/java/com/exxus/scheduler/SchedulerApplication.java
@@ -1,0 +1,24 @@
+package com.exxus.scheduler;
+
+import org.jobrunr.scheduling.JobScheduler;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import com.exxus.integration.cron.jobs.SampleJob;
+
+@SpringBootApplication(scanBasePackages = "com.exxus")
+public class SchedulerApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(SchedulerApplication.class, args);
+  }
+
+  @Bean
+  CommandLineRunner scheduleMinutelyJob(JobScheduler jobScheduler, SampleJob sampleJob) {
+    return args ->
+        jobScheduler.scheduleRecurrently(
+            "sample-job-minutely", "*/1 * * * *", () -> sampleJob.process());
+  }
+}

--- a/services/scheduler/src/main/java/com/exxus/scheduler/api/InternalJobController.java
+++ b/services/scheduler/src/main/java/com/exxus/scheduler/api/InternalJobController.java
@@ -1,0 +1,29 @@
+package com.exxus.scheduler.api;
+
+import org.jobrunr.scheduling.JobScheduler;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.exxus.integration.cron.jobs.SampleJob;
+
+@RestController
+@RequestMapping("/internal/jobs")
+public class InternalJobController {
+
+  private final JobScheduler jobScheduler;
+  private final SampleJob sampleJob;
+
+  public InternalJobController(JobScheduler jobScheduler, SampleJob sampleJob) {
+    this.jobScheduler = jobScheduler;
+    this.sampleJob = sampleJob;
+  }
+
+  @PostMapping("/sample/trigger")
+  public ResponseEntity<Void> triggerSampleJob() {
+    jobScheduler.enqueue(sampleJob::process);
+    return new ResponseEntity<>(HttpStatus.ACCEPTED);
+  }
+}

--- a/services/scheduler/src/main/resources/application.yml
+++ b/services/scheduler/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: scheduler
+  datasource:
+    url: jdbc:postgresql://localhost:5432/exxus_jobs
+    username: exxus
+    password: secret
+
+org:
+  jobrunr:
+    background-job-server:
+      enabled: true
+    dashboard:
+      enabled: true
+      port: 8000
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,5 @@ rootProject.name = "nexxus-backend"
 include("libs:shared")
 include("services:migration")
 include("services:core")
+include("libs:integration:cron")
+include("services:scheduler")


### PR DESCRIPTION
Implement a JobRunr-based cron service, isolating JDBC in a new `scheduler` service while keeping `core` fully reactive (WebFlux + R2DBC).

---
<a href="https://cursor.com/background-agent?bcId=bc-25d43ebe-fdd0-4fe5-a722-7aaba641bf16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25d43ebe-fdd0-4fe5-a722-7aaba641bf16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

